### PR TITLE
Beige 25

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-desktop-base (2025.09.22) unstable; urgency=medium
+
+  * update 25.0.8 
+
+ -- lichenggang <lichenggang@deepin.org>  Mon, 22 Sep 2025 13:15:57 +0800
+
 deepin-desktop-base (2025.08.22) unstable; urgency=medium
 
   * update 25.0.7

--- a/files/os-version-amd
+++ b/files/os-version-amd
@@ -7,5 +7,5 @@ EditionName=Community
 EditionName[en_US]=Community
 EditionName[zh_CN]=社区版
 MajorVersion=25
-MinorVersion=25.0.7
+MinorVersion=25.0.8
 OsBuild=21138.105

--- a/files/os-version-arm
+++ b/files/os-version-arm
@@ -7,5 +7,5 @@ EditionName=Community
 EditionName[en_US]=Community
 EditionName[zh_CN]=社区版
 MajorVersion=25
-MinorVersion=25.0.7
+MinorVersion=25.0.8
 OsBuild=21134.105

--- a/files/os-version-loong
+++ b/files/os-version-loong
@@ -7,5 +7,5 @@ EditionName=Community
 EditionName[en_US]=Community
 EditionName[zh_CN]=社区版
 MajorVersion=25
-MinorVersion=25.0.7
+MinorVersion=25.0.8
 OsBuild=21133.105

--- a/files/os-version-riscv
+++ b/files/os-version-riscv
@@ -7,5 +7,5 @@ EditionName=Community
 EditionName[en_US]=Community
 EditionName[zh_CN]=社区版
 MajorVersion=25
-MinorVersion=25.0.7
+MinorVersion=25.0.8
 OsBuild=21135.105


### PR DESCRIPTION
## Summary by Sourcery

Update Debian changelog and OS version files to reflect the Beige 25 release

Enhancements:
- Bump Debian package changelog to Beige 25
- Update version strings in files/os-version-amd, os-version-arm, os-version-loong, and os-version-riscv for the new release