### PR TITLE
feat: update 25.0.9

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-desktop-base (2025.10.22) unstable; urgency=medium
+
+  * update 25.0.9
+
+ -- lichenggang <lichenggang@deepin.org>  Wed, 22 Oct 2025 11:26:07 +0800
+
 deepin-desktop-base (2025.09.22) unstable; urgency=medium
 
   * update 25.0.8 

--- a/files/os-version-amd
+++ b/files/os-version-amd
@@ -7,5 +7,5 @@ EditionName=Community
 EditionName[en_US]=Community
 EditionName[zh_CN]=社区版
 MajorVersion=25
-MinorVersion=25.0.8
+MinorVersion=25.0.9
 OsBuild=21138.105

--- a/files/os-version-arm
+++ b/files/os-version-arm
@@ -7,5 +7,5 @@ EditionName=Community
 EditionName[en_US]=Community
 EditionName[zh_CN]=社区版
 MajorVersion=25
-MinorVersion=25.0.8
+MinorVersion=25.0.9
 OsBuild=21134.105

--- a/files/os-version-loong
+++ b/files/os-version-loong
@@ -7,5 +7,5 @@ EditionName=Community
 EditionName[en_US]=Community
 EditionName[zh_CN]=社区版
 MajorVersion=25
-MinorVersion=25.0.8
+MinorVersion=25.0.9
 OsBuild=21133.105

--- a/files/os-version-riscv
+++ b/files/os-version-riscv
@@ -7,5 +7,5 @@ EditionName=Community
 EditionName[en_US]=Community
 EditionName[zh_CN]=社区版
 MajorVersion=25
-MinorVersion=25.0.8
+MinorVersion=25.0.9
 OsBuild=21135.105


### PR DESCRIPTION
update 25.0.9

Log:

## Summary by Sourcery

Bump project version to 25.0.9

Build:
- Update Debian changelog to reflect version 25.0.9
- Refresh OS version files for amd, arm, loong, and riscv architectures