### PR TITLE
feat: update 25.0.10

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-desktop-base (2025.11.25) unstable; urgency=medium
+
+  * update 25.0.10.
+
+ -- lichenggang <lichenggang@deepin.org>  Tue, 25 Nov 2025 14:16:31 +0800
+
 deepin-desktop-base (2025.11.19) unstable; urgency=medium
 
   * update OsBuild

--- a/files/os-version-amd
+++ b/files/os-version-amd
@@ -7,5 +7,5 @@ EditionName=Community
 EditionName[en_US]=Community
 EditionName[zh_CN]=社区版
 MajorVersion=25
-MinorVersion=25.0.9
+MinorVersion=25.0.10
 OsBuild=21138.105.100

--- a/files/os-version-arm
+++ b/files/os-version-arm
@@ -7,5 +7,5 @@ EditionName=Community
 EditionName[en_US]=Community
 EditionName[zh_CN]=社区版
 MajorVersion=25
-MinorVersion=25.0.9
+MinorVersion=25.0.10
 OsBuild=21134.105.100

--- a/files/os-version-loong
+++ b/files/os-version-loong
@@ -7,5 +7,5 @@ EditionName=Community
 EditionName[en_US]=Community
 EditionName[zh_CN]=社区版
 MajorVersion=25
-MinorVersion=25.0.9
+MinorVersion=25.0.10
 OsBuild=21133.105.100

--- a/files/os-version-riscv
+++ b/files/os-version-riscv
@@ -7,5 +7,5 @@ EditionName=Community
 EditionName[en_US]=Community
 EditionName[zh_CN]=社区版
 MajorVersion=25
-MinorVersion=25.0.9
+MinorVersion=25.0.10
 OsBuild=21135.105.100


### PR DESCRIPTION
update 25.0.10

Log:

## Summary by Sourcery

Update Debian packaging metadata and OS version marker files to release version 25.0.10.

New Features:
- Introduce support for OS version 25.0.10 across all supported architectures.

Build:
- Refresh Debian changelog for the 25.0.10 release.