### PR TITLE
feat: update os-version 25.0.12

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-desktop-base (2026.01.26) unstable; urgency=medium
+
+  * update 25.0.12.
+
+ -- lichenggang <lichenggang@deepin.org>  Mon, 26 Jan 2026 13:44:09 +0800
+
 deepin-desktop-base (2025.12.22) unstable; urgency=medium
 
   * update 25.0.11.

--- a/files/os-version-amd
+++ b/files/os-version-amd
@@ -7,5 +7,5 @@ EditionName=Community
 EditionName[en_US]=Community
 EditionName[zh_CN]=社区版
 MajorVersion=25
-MinorVersion=25.0.11
-OsBuild=21138.106.100
+MinorVersion=25.0.12
+OsBuild=21138.107.100

--- a/files/os-version-arm
+++ b/files/os-version-arm
@@ -7,5 +7,5 @@ EditionName=Community
 EditionName[en_US]=Community
 EditionName[zh_CN]=社区版
 MajorVersion=25
-MinorVersion=25.0.11
-OsBuild=21134.106.100
+MinorVersion=25.0.12
+OsBuild=21134.107.100

--- a/files/os-version-loong
+++ b/files/os-version-loong
@@ -7,5 +7,5 @@ EditionName=Community
 EditionName[en_US]=Community
 EditionName[zh_CN]=社区版
 MajorVersion=25
-MinorVersion=25.0.11
-OsBuild=21133.106.100
+MinorVersion=25.0.12
+OsBuild=21133.107.100

--- a/files/os-version-riscv
+++ b/files/os-version-riscv
@@ -7,5 +7,5 @@ EditionName=Community
 EditionName[en_US]=Community
 EditionName[zh_CN]=社区版
 MajorVersion=25
-MinorVersion=25.0.11
-OsBuild=21135.106.100
+MinorVersion=25.0.12
+OsBuild=21135.107.100


### PR DESCRIPTION
Log:

## Summary by Sourcery

Bump the recorded OS version to 25.0.12 across Debian packaging metadata and per-architecture version files.

New Features:
- Update per-architecture OS version descriptors to 25.0.12.

Enhancements:
- Refresh Debian changelog to reflect the new 25.0.12 OS release.