### PR TITLE
feat: update os-version 25.0.13

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-desktop-base (2026.01.27) unstable; urgency=medium
+
+  * update 25.0.13.
+
+ -- lichenggang <lichenggang@deepin.org>  Tue, 03 Mar 2026 09:29:04 +0800
+
 deepin-desktop-base (2026.01.26) unstable; urgency=medium
 
   * update 25.0.12.

--- a/files/os-version-amd
+++ b/files/os-version-amd
@@ -7,5 +7,5 @@ EditionName=Community
 EditionName[en_US]=Community
 EditionName[zh_CN]=社区版
 MajorVersion=25
-MinorVersion=25.0.12
-OsBuild=21138.107.100
+MinorVersion=25.0.13
+OsBuild=21138.108.100

--- a/files/os-version-arm
+++ b/files/os-version-arm
@@ -7,5 +7,5 @@ EditionName=Community
 EditionName[en_US]=Community
 EditionName[zh_CN]=社区版
 MajorVersion=25
-MinorVersion=25.0.12
-OsBuild=21134.107.100
+MinorVersion=25.0.13
+OsBuild=21134.108.100

--- a/files/os-version-loong
+++ b/files/os-version-loong
@@ -7,5 +7,5 @@ EditionName=Community
 EditionName[en_US]=Community
 EditionName[zh_CN]=社区版
 MajorVersion=25
-MinorVersion=25.0.12
-OsBuild=21133.107.100
+MinorVersion=25.0.13
+OsBuild=21133.108.100

--- a/files/os-version-riscv
+++ b/files/os-version-riscv
@@ -7,5 +7,5 @@ EditionName=Community
 EditionName[en_US]=Community
 EditionName[zh_CN]=社区版
 MajorVersion=25
-MinorVersion=25.0.12
-OsBuild=21135.107.100
+MinorVersion=25.0.13
+OsBuild=21135.108.100


### PR DESCRIPTION
Bump the recorded OS version to 25.0.13 across Debian packaging metadata and per-architecture version files.