### PR TITLE
feat: update os-version 25.1.0

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-desktop-base (2026.03.25) unstable; urgency=medium
+
+  * update 25.1.0.
+
+ -- lichenggang <lichenggang@deepin.org>  Wed, 25 Mar 2026 21:08:28 +0800
+
 deepin-desktop-base (2026.01.27) unstable; urgency=medium
 
   * update 25.0.13.

--- a/files/os-version-amd
+++ b/files/os-version-amd
@@ -7,5 +7,5 @@ EditionName=Community
 EditionName[en_US]=Community
 EditionName[zh_CN]=社区版
 MajorVersion=25
-MinorVersion=25.0.13
-OsBuild=21138.108.100
+MinorVersion=25.1.0
+OsBuild=21138.100.100

--- a/files/os-version-arm
+++ b/files/os-version-arm
@@ -7,5 +7,5 @@ EditionName=Community
 EditionName[en_US]=Community
 EditionName[zh_CN]=社区版
 MajorVersion=25
-MinorVersion=25.0.13
-OsBuild=21134.108.100
+MinorVersion=25.1.0
+OsBuild=21134.100.100

--- a/files/os-version-loong
+++ b/files/os-version-loong
@@ -7,5 +7,5 @@ EditionName=Community
 EditionName[en_US]=Community
 EditionName[zh_CN]=社区版
 MajorVersion=25
-MinorVersion=25.0.13
-OsBuild=21133.108.100
+MinorVersion=25.1.0
+OsBuild=21133.100.100

--- a/files/os-version-riscv
+++ b/files/os-version-riscv
@@ -7,5 +7,5 @@ EditionName=Community
 EditionName[en_US]=Community
 EditionName[zh_CN]=社区版
 MajorVersion=25
-MinorVersion=25.0.13
-OsBuild=21135.108.100
+MinorVersion=25.1.0
+OsBuild=21135.100.100


### PR DESCRIPTION
## Summary by Sourcery

Bump the packaged OS version metadata to 25.1.0 across all architectures and update the Debian changelog accordingly.

New Features:
- Update OS version metadata files for amd, arm, loong, and riscv architectures to 25.1.0.

Enhancements:
- Refresh the Debian changelog entry to reflect the new 25.1.0 OS version release.