### PR TITLE
feat: update os-version 25.2.1

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-desktop-base (2026.07.30) unstable; urgency=medium
+
+  * update 25.2.1.
+
+ -- lichenggang <lichenggang@deepin.org>  Thu, 30 Jul 2026 10:11:01 +0800
+
 deepin-desktop-base (2026.06.30) unstable; urgency=medium
 
   * update 25.2.0.

--- a/files/os-version-amd
+++ b/files/os-version-amd
@@ -7,5 +7,5 @@ EditionName=Community
 EditionName[en_US]=Community
 EditionName[zh_CN]=社区版
 MajorVersion=25
-MinorVersion=25.2.0
-OsBuild=21138.100.100
+MinorVersion=25.2.1
+OsBuild=21138.102.100

--- a/files/os-version-arm
+++ b/files/os-version-arm
@@ -7,5 +7,5 @@ EditionName=Community
 EditionName[en_US]=Community
 EditionName[zh_CN]=社区版
 MajorVersion=25
-MinorVersion=25.2.0
-OsBuild=21134.100.100
+MinorVersion=25.2.1
+OsBuild=21134.102.100

--- a/files/os-version-loong
+++ b/files/os-version-loong
@@ -7,5 +7,5 @@ EditionName=Community
 EditionName[en_US]=Community
 EditionName[zh_CN]=社区版
 MajorVersion=25
-MinorVersion=25.2.0
-OsBuild=21133.100.100
+MinorVersion=25.2.1
+OsBuild=21133.102.100

--- a/files/os-version-riscv
+++ b/files/os-version-riscv
@@ -7,5 +7,5 @@ EditionName=Community
 EditionName[en_US]=Community
 EditionName[zh_CN]=社区版
 MajorVersion=25
-MinorVersion=25.2.0
-OsBuild=21135.100.100
+MinorVersion=25.2.1
+OsBuild=21135.102.100


### PR DESCRIPTION
Log:  update os-version 25.2.1

## Summary by Sourcery

Bump OS version metadata to 25.2.1 across changelog and architecture-specific version files.